### PR TITLE
[Step 4] 동일 사용자 동일 신청에 대한 멱등성 구현 및 테스트 작성

### DIFF
--- a/src/main/kotlin/com/hhplus/lecture/application/lecture/LectureFacade.kt
+++ b/src/main/kotlin/com/hhplus/lecture/application/lecture/LectureFacade.kt
@@ -4,12 +4,12 @@ import com.hhplus.lecture.application.lecture.dto.LectureInfo
 import com.hhplus.lecture.application.lecture.dto.LectureRegisterInfo
 import com.hhplus.lecture.application.lecture.mapper.LectureMapper
 import com.hhplus.lecture.domain.lecture.Lecture
+import com.hhplus.lecture.domain.lecture.LectureRegistration
 import com.hhplus.lecture.domain.lecture.LectureService
 import com.hhplus.lecture.domain.user.User
 import com.hhplus.lecture.domain.user.UserService
 import com.hhplus.lecture.util.DateValidator
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
 @Component
@@ -18,12 +18,11 @@ class LectureFacade(
     private val lectureService: LectureService,
     private val lectureMapper: LectureMapper,
 ) {
-    @Transactional
     fun register(
         info: LectureRegisterInfo,
     ) : LectureRegisterInfo {
         val user: User = userService.findById(info.userId)
-        val lectureRegistration = lectureService.register(user, info.lectureId)
+        val lectureRegistration: LectureRegistration = lectureService.register(user, info.lectureId)
         return lectureMapper.toRegisterInfo(lectureRegistration)
     }
 

--- a/src/main/kotlin/com/hhplus/lecture/domain/common/exception/RegistrationAlreadyExistsException.kt
+++ b/src/main/kotlin/com/hhplus/lecture/domain/common/exception/RegistrationAlreadyExistsException.kt
@@ -1,0 +1,3 @@
+package com.hhplus.lecture.domain.common.exception
+
+class RegistrationAlreadyExistsException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/hhplus/lecture/domain/lecture/LectureRegistrationRepository.kt
+++ b/src/main/kotlin/com/hhplus/lecture/domain/lecture/LectureRegistrationRepository.kt
@@ -10,4 +10,6 @@ interface LectureRegistrationRepository {
     fun findByUser(user: User): List<LectureRegistration>
 
     fun findLecturesByUser(user: User): List<Lecture>
+
+    fun findByUserIdAndLectureId(userId: Long, lectureId: Long): LectureRegistration?
 }

--- a/src/main/kotlin/com/hhplus/lecture/domain/lecture/LectureService.kt
+++ b/src/main/kotlin/com/hhplus/lecture/domain/lecture/LectureService.kt
@@ -1,6 +1,7 @@
 package com.hhplus.lecture.domain.lecture
 
 import com.hhplus.lecture.domain.common.exception.LectureNotFoundException
+import com.hhplus.lecture.domain.common.exception.RegistrationAlreadyExistsException
 import com.hhplus.lecture.domain.user.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -24,8 +25,16 @@ class LectureService(
 
     @Transactional
     fun register(user: User, lectureId: Long): LectureRegistration {
+        checkIfAlreadyRegistered(user, lectureId)
         val lecture = findByIdWithLock(lectureId).incrementRegisteredCount()
         return lectureRegistrationRepository.save(LectureRegistration(user = user, lecture = lecture))
+    }
+
+    fun checkIfAlreadyRegistered(user: User, lectureId: Long) {
+        val existingRegistration = lectureRegistrationRepository.findByUserIdAndLectureId(user.id!!, lectureId)
+        if (existingRegistration != null) {
+            throw RegistrationAlreadyExistsException("이미 신청한 강의입니다.")
+        }
     }
 
     fun getAvailableLecturesByDate(date: LocalDate): List<Lecture> {

--- a/src/main/kotlin/com/hhplus/lecture/infrastructure/repository/lecture/LectureRegistrationJpaRepository.kt
+++ b/src/main/kotlin/com/hhplus/lecture/infrastructure/repository/lecture/LectureRegistrationJpaRepository.kt
@@ -16,4 +16,5 @@ interface LectureRegistrationJpaRepository : JpaRepository<LectureRegistration, 
         WHERE lr.user = :user
     """)
     fun findLecturesByUser(@Param("user") user: User): List<Lecture>
+    fun findByUserIdAndLectureId(userId: Long, lectureId: Long): LectureRegistration?
 }

--- a/src/main/kotlin/com/hhplus/lecture/infrastructure/repository/lecture/LectureRegistrationRepositoryJpaImpl.kt
+++ b/src/main/kotlin/com/hhplus/lecture/infrastructure/repository/lecture/LectureRegistrationRepositoryJpaImpl.kt
@@ -24,4 +24,8 @@ class LectureRegistrationRepositoryJpaImpl(
     override fun findLecturesByUser(user: User): List<Lecture> {
         return repository.findLecturesByUser(user)
     }
+
+    override fun findByUserIdAndLectureId(userId: Long, lectureId: Long): LectureRegistration? {
+        return repository.findByUserIdAndLectureId(userId, lectureId)
+    }
 }

--- a/src/main/kotlin/com/hhplus/lecture/interfaces/advice/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/hhplus/lecture/interfaces/advice/GlobalExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.hhplus.lecture.interfaces.advice
 import com.hhplus.lecture.domain.common.exception.LectureNotFoundException
 import com.hhplus.lecture.domain.common.exception.MaxSeatsReachedException
 import com.hhplus.lecture.domain.common.exception.UserNotFoundException
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -26,5 +27,9 @@ class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(ex: IllegalArgumentException): ResponseEntity<String> {
         return ResponseEntity(ex.message ?: "잘못된 요청입니다.", HttpStatus.BAD_REQUEST)
+    }
+    @ExceptionHandler(DataIntegrityViolationException::class)
+    fun handleUniqueConstraintViolation(ex: DataIntegrityViolationException): ResponseEntity<String> {
+        return ResponseEntity("이미 신청한 강의입니다.", HttpStatus.BAD_REQUEST)
     }
 }

--- a/src/test/kotlin/com/hhplus/lecture/domain/lecture/LectureServiceTest.kt
+++ b/src/test/kotlin/com/hhplus/lecture/domain/lecture/LectureServiceTest.kt
@@ -1,10 +1,9 @@
 package com.hhplus.lecture.domain.lecture
 
 import com.hhplus.lecture.domain.common.exception.LectureNotFoundException
+import com.hhplus.lecture.domain.common.exception.RegistrationAlreadyExistsException
 import com.hhplus.lecture.domain.user.User
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -48,6 +47,7 @@ class LectureServiceTest {
 
         every { lectureRegistrationRepository.save(any()) } returns lectureRegistration
         every { lectureRepository.findByIdOrNullWithLock(lecture.id!!) } returns lecture
+        every { lectureRegistrationRepository.findByUserIdAndLectureId(userId, lectureId) } returns null
 
         // when
         val result: LectureRegistration = lectureService.register(user, lectureId)
@@ -56,6 +56,25 @@ class LectureServiceTest {
         assertEquals(userId, result.user.id)
         assertEquals(lectureId, result.lecture.id)
         assertTrue(lecture.registeredCount == 1)
+    }
+
+    @Test
+    fun `사용자가 동일한 강의를 신청할 경우 예외가 발생해야 한다`() {
+        // given
+        val userId = 1L
+        val lectureId = 1L
+        val user = User(id = userId, name = "홍길동", email = "hong@example.com")
+        val lecture = Lecture(id = lectureId, title = "코틀린 강의", lecturerName = "강사1", date = LocalDate.now(), registeredCount = 0)
+        val lectureRegistration = LectureRegistration(user = user, lecture = lecture)
+
+        every { lectureRegistrationRepository.findByUserIdAndLectureId(userId, lectureId) } returns lectureRegistration
+
+        // when & then
+        val exception = assertThrows<RegistrationAlreadyExistsException> {
+            lectureService.register(user, lectureId)
+        }
+
+        assertEquals("이미 신청한 강의입니다.", exception.message)
     }
 
     @Test


### PR DESCRIPTION
## 작업 내역

1. 동일한 사용자가 같은 특강에 대해 다수 요청을 보내도 최초 1회만 수행되도록 구현
2. 해당 내용을 검증하는 통합 테스트 코드 작성

<br/>

## 의사결정 흐름

1. 수강신청에 대한 멱등성 구현
  - 동일한 유저가 동일한 강의에 중복으로 수강 신청이 되지 않도록 구현하기 위해 `수강등록` 테이블의 `user_id`와 `lecture_id`를 복합 유니크 키로 설정했습니다. 이를 통해 `수강등록` 테이블에서 무결성 제약조건에 위배되었을 때 해당 트랜잭션을 롤백하도록 구현했습니다.


<br/>

## 리뷰 포인트
- `LectureService`의 `register()`를 아래와 같이 구현했는데, 처음에는 무결성 제약조건에 위배되면 트랜잭션 롤백을 시키는 로직만 생각했었습니다. 그런데 이미 수강 신청한 유저가 계속해서 요청을 보낸다면 `lectureRegistrationRepository.save()` 에서 무결성 검사가 이루어지기 전에 `findByIdWithLock()`을 통해 강의 테이블의 해당 강의 레코드에 락이 걸리게 되서 다른 사용자들의 요청이 지연될 수 있다고 판단했습니다.  그래서 락을 걸기 전에 `checkIfAlreadyRegistered()`을 호출해서 이미 수강신청 완료한 사용자인지 조회하는 로직을 추가했는데 이 방식이 맞게  생각한건지가 궁금합니다.
```kotlin
@Transactional
fun register(user: User, lectureId: Long): LectureRegistration {
    checkIfAlreadyRegistered(user, lectureId) // 추가
    val lecture = findByIdWithLock(lectureId).incrementRegisteredCount()
    return lectureRegistrationRepository.save(LectureRegistration(user = user, lecture = lecture))
}
```
